### PR TITLE
[codex] Move server review to blocker-first flow

### DIFF
--- a/frontend/app/app/server-review/page.js
+++ b/frontend/app/app/server-review/page.js
@@ -134,7 +134,7 @@ function ServerReviewPageContent() {
   const router = useRouter();
 
   const [error, setError] = useState("");
-  const [success, setSuccess] = useState("Step 1 is ready. Save one server target, then run one check.");
+  const [success, setSuccess] = useState("Start here: save one server target, then run one check.");
   const [servers, setServers] = useState([]);
   const [serverTestResults, setServerTestResults] = useState({});
   const [serverDiagnostics, setServerDiagnostics] = useState({});
@@ -206,8 +206,156 @@ function ServerReviewPageContent() {
     items[0] ||
     null;
 
+  const noServers = items.length === 0;
   const readyCount = items.filter((item) => item.segment === "ready").length;
   const reviewCount = items.filter((item) => item.segment !== "ready").length;
+  const selectedReadyItem =
+    selectedItem?.segment === "ready"
+      ? selectedItem
+      : items.find((item) => item.segment === "ready") || null;
+  const selectedNeedsReviewItem =
+    selectedItem && selectedItem.segment !== "ready"
+      ? selectedItem
+      : items.find((item) => item.segment !== "ready") || null;
+  const heroSpotlight = noServers
+    ? {
+        badge: "Do this now",
+        title: "Save your first server target",
+        detail: "This is the only action that matters until DeployMate knows which machine it should reach.",
+        support: "After you save one server, this page switches to one simple readiness check.",
+        actionLabel: "Save first server",
+        actionKind: "create",
+      }
+    : selectedReadyItem
+      ? {
+          badge: "Step 1 complete",
+          title: `${selectedReadyItem.label} is ready for Step 2`,
+          detail: "You already have one confirmed server. Keep the momentum and choose what to run next.",
+          support: "You can always come back later, but the main path has already moved on from this screen.",
+          actionLabel: "Go to Step 2",
+          actionKind: "continue",
+          actionHref: `/app/deployment-workflow?server=${selectedReadyItem.id}&source=server-review`,
+        }
+      : {
+          badge: "Do this now",
+          title: `Check ${selectedNeedsReviewItem?.label || "your saved server"}`,
+          detail: "You already saved a server. The next useful move is one readiness check, not another form.",
+          support: selectedNeedsReviewItem
+            ? `${selectedNeedsReviewItem.label} is the best next target to confirm before you continue.`
+            : "Pick one saved server and finish the check before you add more targets.",
+          actionLabel:
+            selectedItem && selectedItem.segment !== "ready"
+              ? "Open this server check"
+              : "Open next server check",
+          actionKind: "queue",
+        };
+  const stepCards = [
+    {
+      id: "save",
+      label: "1. Save",
+      title: "Save one server",
+      detail: "Give DeployMate one SSH target first.",
+      state: noServers ? "current" : "complete",
+    },
+    {
+      id: "check",
+      label: "2. Check",
+      title: "Run one check",
+      detail: "Confirm the server is reachable and ready.",
+      state: noServers ? "upcoming" : selectedReadyItem ? "complete" : "current",
+    },
+    {
+      id: "continue",
+      label: "3. Continue",
+      title: "Move to app setup",
+      detail: "Choose what to run only after one server looks ready.",
+      state: selectedReadyItem ? "current" : "upcoming",
+    },
+  ];
+  const createSectionEyebrow = noServers ? "Do this now" : "Only if needed";
+  const createSectionTitle = noServers
+    ? "Save your first server target"
+    : "Add another server only if this one is not the right target";
+  const createSectionCopy = noServers
+    ? "Fill in the machine details once, save them, and then move straight to one check."
+    : selectedReadyItem
+      ? "You already have a server that is ready for Step 2. This form is secondary now."
+      : "A saved server already exists. Finish its check before adding another target unless you picked the wrong machine.";
+  const createSubmitLabel = noServers ? "Save first server" : "Save another server";
+  const nextPanelLabel = noServers
+    ? "What happens next"
+    : selectedReadyItem
+      ? "You can leave this page"
+      : "You are almost done here";
+  const nextPanelTitle = noServers
+    ? "One good server is enough for this step"
+    : selectedReadyItem
+      ? `${selectedReadyItem.label} is ready for Step 2`
+      : "One saved server still needs a quick check";
+  const nextPanelCopy = noServers
+    ? "You do not need a list of servers yet. Save one, confirm it, and only then move into app setup."
+    : selectedReadyItem
+      ? "Use the ready server in Step 2. Come back only if you need to fix or replace the saved connection details."
+      : "Stay focused on one saved server until DeployMate can confirm that it is safe to use for the first rollout.";
+  const queueTitle = noServers
+    ? "Your saved servers will appear here"
+    : selectedReadyItem
+      ? "One server is already ready"
+      : "Choose one saved server to confirm";
+  const queueDescription = noServers
+    ? "After you save the first target above, come here to run the first check."
+    : selectedReadyItem
+      ? "You can review other servers here, but the clearest next step is already app setup."
+      : "Open one server, run the readiness check, and move on as soon as it looks safe.";
+  const emptyQueueText = noServers
+    ? "No server saved yet. Start with the form above, save one server, then come back here for the first check."
+    : "No saved servers match the current filters.";
+
+  function focusCreateServer() {
+    const createSection = document.getElementById("server-review-create-server-section");
+    createSection?.scrollIntoView({ behavior: "smooth", block: "start" });
+
+    window.setTimeout(() => {
+      const nameInput = document.querySelector('[data-testid="server-review-create-name"]');
+      if (nameInput instanceof HTMLElement) {
+        nameInput.focus();
+      }
+    }, 180);
+  }
+
+  function focusServerQueue(itemId = "") {
+    const nextItemId = itemId || selectedNeedsReviewItem?.id || selectedReadyItem?.id || "";
+    if (nextItemId) {
+      setSelectedItemId(nextItemId);
+    }
+
+    window.setTimeout(() => {
+      const taskPanel = nextItemId
+        ? document.querySelector(`[data-testid="server-review-tasks-${nextItemId}"]`)
+        : null;
+      if (taskPanel instanceof HTMLElement) {
+        taskPanel.scrollIntoView({ behavior: "smooth", block: "start" });
+        return;
+      }
+
+      const queueRoot = document.getElementById("server-review-live-queue");
+      queueRoot?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 120);
+  }
+
+  function handleHeroPrimaryAction() {
+    if (heroSpotlight.actionKind === "create") {
+      focusCreateServer();
+      return;
+    }
+
+    if (heroSpotlight.actionKind === "continue" && heroSpotlight.actionHref) {
+      router.push(heroSpotlight.actionHref);
+      return;
+    }
+
+    focusServerQueue();
+  }
 
   useEffect(() => {
     if (!selectedItem) {
@@ -244,7 +392,11 @@ function ServerReviewPageContent() {
       if (nextServers[0] && !selectedItemId) {
         setSelectedItemId(nextServers[0].id);
       }
-      setSuccess(`Loaded ${nextServers.length} live server target${nextServers.length === 1 ? "" : "s"}.`);
+      setSuccess(
+        nextServers.length === 0
+          ? "Start here: save one server target, then run one check."
+          : `Loaded ${nextServers.length} live server target${nextServers.length === 1 ? "" : "s"}.`,
+      );
     } catch (requestError) {
       if (requestError instanceof Error && requestError.status === 401) {
         router.replace("/login");
@@ -502,6 +654,18 @@ function ServerReviewPageContent() {
             <p className="formHint serverReviewSubtleCopy">
               Keep this step simple. You do not need rollout settings, templates, or runtime review yet.
             </p>
+            <div className="serverReviewStepStrip" aria-label="Server review path">
+              {stepCards.map((step) => (
+                <article
+                  key={step.id}
+                  className={`serverReviewStepCard is${step.state[0].toUpperCase()}${step.state.slice(1)}`}
+                >
+                  <span>{step.label}</span>
+                  <strong>{step.title}</strong>
+                  <p>{step.detail}</p>
+                </article>
+              ))}
+            </div>
           </div>
           <div className="serverReviewHeroRail">
             <div className="buttonRow serverReviewHeroActions">
@@ -519,11 +683,17 @@ function ServerReviewPageContent() {
               </button>
             </div>
             <div className="serverReviewHeroPanel">
-              <span className="serverReviewPanelLabel">Finish Step 1</span>
-              <strong>Save one server target. Then check that DeployMate can use it.</strong>
-              <p>
-                A beginner only needs one confirmed target here. Everything else can wait until Step 2.
-              </p>
+              <span className="serverReviewPanelLabel">{heroSpotlight.badge}</span>
+              <strong>{heroSpotlight.title}</strong>
+              <p>{heroSpotlight.detail}</p>
+              <p className="serverReviewHeroSpotlightNote">{heroSpotlight.support}</p>
+              <button
+                type="button"
+                className="landingButton primaryButton serverReviewHeroPrimaryAction"
+                onClick={handleHeroPrimaryAction}
+              >
+                {heroSpotlight.actionLabel}
+              </button>
               <div className="serverReviewHeroStats" aria-label="Server review summary">
                 <div className="serverReviewHeroStat">
                   <span>Saved</span>
@@ -552,17 +722,20 @@ function ServerReviewPageContent() {
       />
 
       <article
-        className="card formCard workspaceGuidePanel serverReviewCreateCard serverReviewReveal"
+        className={`card formCard workspaceGuidePanel serverReviewCreateCard serverReviewReveal ${noServers ? "" : "isSecondary"}`.trim()}
         data-testid="server-review-create-card"
       >
         <div className="serverReviewCreateLayout">
-          <div id="server-review-create-server-section" className="workspaceGlancePanel serverReviewCreatePanel">
+          <div
+            id="server-review-create-server-section"
+            className={`workspaceGlancePanel serverReviewCreatePanel ${noServers ? "" : "isSecondary"}`.trim()}
+          >
             <div className="workspaceGlanceHeader">
-              <span className="eyebrow">Step 1 action</span>
-              <strong>Save one server target</strong>
+              <span className="eyebrow">{createSectionEyebrow}</span>
+              <strong>{createSectionTitle}</strong>
             </div>
             <p className="formHint serverReviewSubtleCopy">
-              Fill in the machine details, save them once, then run a check before you move on.
+              {createSectionCopy}
             </p>
             <form className="form" onSubmit={handleCreateServer} data-testid="server-review-create-server">
               <label className="field">
@@ -646,22 +819,20 @@ function ServerReviewPageContent() {
               <div className="formActions">
                 <button
                   type="submit"
-                  className="landingButton primaryButton"
+                  className={noServers ? "landingButton primaryButton" : "secondaryButton serverReviewCreateSecondaryAction"}
                   disabled={serverSubmitting}
                   data-testid="server-review-create-submit"
                 >
-                  {serverSubmitting ? "Saving..." : "Save server target"}
+                  {serverSubmitting ? "Saving..." : createSubmitLabel}
                 </button>
               </div>
             </form>
           </div>
 
           <aside className="serverReviewSoftPanel serverReviewNextPanel">
-            <span className="serverReviewPanelLabel">Leave this page when</span>
-            <h2>One server looks ready for Step 2</h2>
-            <p className="formHint">
-              You are done here once one saved target passes a quick check and looks safe to use.
-            </p>
+            <span className="serverReviewPanelLabel">{nextPanelLabel}</span>
+            <h2>{nextPanelTitle}</h2>
+            <p className="formHint">{nextPanelCopy}</p>
             <div className="serverReviewMiniSteps">
               <div className="serverReviewMiniStep">
                 <strong>1. Save one server target</strong>
@@ -685,11 +856,9 @@ function ServerReviewPageContent() {
           <div className="serverReviewToolbarHeader">
             <div>
               <span className="serverReviewPanelLabel">Saved servers</span>
-              <h2>Open one saved server and confirm it</h2>
+              <h2>{queueTitle}</h2>
             </div>
-            <p className="formHint">
-              Stay focused on one server at a time. If it looks ready, move straight to Step 2.
-            </p>
+            <p className="formHint">{queueDescription}</p>
           </div>
           <label className="field serverReviewFilterField">
             <span>Show</span>
@@ -710,14 +879,14 @@ function ServerReviewPageContent() {
         <AdminSurfaceQueue
           className="serverReviewQueueShell serverReviewReveal"
           title="Your servers"
-          description="Open a server, check it, or continue to app setup."
+          description={queueDescription}
           searchLabel="Search saved servers"
           searchValue={query}
           onSearchChange={(event) => setQuery(event.target.value)}
           searchPlaceholder={starterStrings.searchPlaceholder}
           searchTestId="server-review-search"
           emptyTestId="server-review-empty"
-          emptyText="No saved servers match the current filters."
+          emptyText={emptyQueueText}
           items={filteredItems}
         >
           {filteredItems.map((item) => (

--- a/frontend/app/app/server-review/page.js
+++ b/frontend/app/app/server-review/page.js
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Suspense, useEffect, useMemo, useState } from "react";
+import { readJsonOrError } from "../../lib/admin-page-utils";
+import { smokeMode, smokeUser } from "../../lib/smoke-fixtures";
 import {
   AdminFeedbackBanners,
   AdminSurfaceQueue,
@@ -21,6 +23,11 @@ import {
   runServerReviewStarterAction,
   updateServerReviewServer,
 } from "./starter-api";
+
+const apiBaseUrl =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8000";
+const localDeploymentsEnabled =
+  process.env.NEXT_PUBLIC_LOCAL_DEPLOYMENTS_ENABLED !== "0";
 
 function buildServerMeta(server, diagnostics, suggestedPorts) {
   const target = `${server.username}@${server.host}:${server.port}`;
@@ -133,6 +140,9 @@ function InlineHelp({ id, label, text, testId, isOpen, onToggle }) {
 function ServerReviewPageContent() {
   const router = useRouter();
 
+  const [authChecked, setAuthChecked] = useState(smokeMode);
+  const [authFallbackVisible, setAuthFallbackVisible] = useState(false);
+  const [currentUser, setCurrentUser] = useState(smokeMode ? smokeUser : null);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("Start here: save one server target, then run one check.");
   const [servers, setServers] = useState([]);
@@ -172,6 +182,13 @@ function ServerReviewPageContent() {
     }),
     [serverDiagnostics, serverSuggestedPorts, serverTestResults],
   );
+  const canAccessServers = Boolean(currentUser?.is_admin);
+  const blockedLead = localDeploymentsEnabled
+    ? "Saved server targets stay with admins. Your next step is choosing what to run in Deployment Workflow."
+    : "Step 1 is admin-only in this remote-only workspace. Ask an admin to save and confirm one server target first.";
+  const blockedSupport = localDeploymentsEnabled
+    ? "This page should not distract you with server-edit controls you cannot use."
+    : "Until an admin confirms the target, this page should not pretend you can finish server setup here.";
 
   const items = useMemo(
     () => servers.map((server) => mapServerToItem(server, runtimeState)),
@@ -357,6 +374,16 @@ function ServerReviewPageContent() {
     focusServerQueue();
   }
 
+  async function fetchCurrentUser() {
+    const response = await fetch(`${apiBaseUrl}/auth/me`, {
+      cache: "no-store",
+      credentials: "include",
+    });
+    const data = await readJsonOrError(response, "Authentication failed.");
+    setCurrentUser(data);
+    return data;
+  }
+
   useEffect(() => {
     if (!selectedItem) {
       setEditForm({
@@ -378,7 +405,13 @@ function ServerReviewPageContent() {
     });
   }, [selectedItemId, selectedItem]);
 
-  async function loadServers(silent = false) {
+  async function loadServers(silent = false, user = currentUser) {
+    if (!user?.is_admin) {
+      setServers([]);
+      setLoading(false);
+      return;
+    }
+
     if (!silent) {
       setLoading(true);
       setError("");
@@ -615,8 +648,39 @@ function ServerReviewPageContent() {
   }
 
   useEffect(() => {
-    loadServers();
-  }, []);
+    if (smokeMode) {
+      return;
+    }
+
+    async function checkAuthAndLoad() {
+      try {
+        const user = await fetchCurrentUser();
+        setAuthChecked(true);
+        setAuthFallbackVisible(false);
+        if (user?.is_admin) {
+          await loadServers(false, user);
+        }
+      } catch {
+        router.replace("/login");
+      }
+    }
+
+    checkAuthAndLoad();
+  }, [router]);
+
+  useEffect(() => {
+    if (smokeMode || authChecked) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setAuthFallbackVisible(true);
+    }, 3500);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [authChecked]);
 
   useEffect(() => {
     function handlePointerDown(event) {
@@ -640,6 +704,83 @@ function ServerReviewPageContent() {
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, []);
+
+  if (!authChecked) {
+    return (
+      <main className="page">
+        <div className="container">
+          {authFallbackVisible ? (
+            <div className="card formCard">
+              <h1>Checking authentication</h1>
+              <div className="banner subtle">
+                This page usually redirects into the authenticated workspace automatically. If that
+                bootstrap flow stalls, use the direct entry points below.
+              </div>
+              <div className="formActions">
+                <Link href="/login" className="linkButton">
+                  Open login
+                </Link>
+                <Link href="/register" className="linkButton">
+                  Create trial account
+                </Link>
+                <Link href="/" className="linkButton">
+                  Back to homepage
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <div className="empty">Checking authentication...</div>
+          )}
+        </div>
+      </main>
+    );
+  }
+
+  if (!canAccessServers) {
+    return (
+      <main className="workspaceShell serverReviewPage">
+        <article className="card formCard workspaceGuidePanel" data-testid="server-review-blocked-card">
+          <div className="workspaceGlanceHeader">
+            <span className="eyebrow">Server setup stays with admins</span>
+            <strong data-testid="server-review-blocked-title">Ask an admin to finish Step 1</strong>
+          </div>
+          <p className="serverReviewLead">{blockedLead}</p>
+          <p className="formHint">{blockedSupport}</p>
+          <div className="banner subtle" data-testid="server-review-blocked-banner">
+            {localDeploymentsEnabled
+              ? "The real next step for you is Deployment Workflow, not saved server management."
+              : "The real next step is waiting for one admin-managed target, then returning to Deployment Workflow."}
+          </div>
+          <div className="serverReviewMiniSteps">
+            <div className="serverReviewMiniStep">
+              <strong>1. Ask an admin</strong>
+              <p>One saved server target has to be confirmed before this path opens for remote rollout.</p>
+            </div>
+            <div className="serverReviewMiniStep">
+              <strong>2. Return to Step 2</strong>
+              <p>Once the target is ready, use Deployment Workflow to choose what app should run.</p>
+            </div>
+            <div className="serverReviewMiniStep">
+              <strong>3. Keep the next click obvious</strong>
+              <p>Do not stay on a blocked page when the real next move lives somewhere else.</p>
+            </div>
+          </div>
+          <div className="formActions">
+            <Link href="/app" className="linkButton" data-testid="server-review-blocked-overview-link">
+              Back to overview
+            </Link>
+            <Link
+              href="/app/deployment-workflow"
+              className="landingButton primaryButton"
+              data-testid="server-review-blocked-workflow-link"
+            >
+              Open deployment workflow
+            </Link>
+          </div>
+        </article>
+      </main>
+    );
+  }
 
   return (
     <main className="workspaceShell serverReviewPage">

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -820,6 +820,64 @@ summary:focus-visible {
   max-width: 600px;
 }
 
+.serverReviewStepStrip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.serverReviewStepCard {
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px;
+  border: 1px solid rgba(215, 226, 236, 0.92);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.serverReviewStepCard span {
+  color: #73849a;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.serverReviewStepCard strong {
+  color: #132238;
+  font-family: var(--font-display), sans-serif;
+  font-size: 21px;
+  letter-spacing: -0.03em;
+}
+
+.serverReviewStepCard p {
+  margin: 0;
+  color: #5f6675;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.serverReviewStepCard.isCurrent {
+  border-color: rgba(197, 166, 111, 0.74);
+  background:
+    linear-gradient(180deg, rgba(255, 250, 242, 0.96) 0%, rgba(250, 245, 236, 0.94) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.88),
+    0 18px 34px rgba(201, 147, 56, 0.1);
+}
+
+.serverReviewStepCard.isComplete {
+  border-color: rgba(191, 211, 204, 0.9);
+  background:
+    linear-gradient(180deg, rgba(245, 251, 248, 0.96) 0%, rgba(238, 247, 242, 0.94) 100%);
+}
+
+.serverReviewStepCard.isUpcoming {
+  background: rgba(255, 255, 255, 0.58);
+}
+
 .serverReviewHeroRail {
   display: grid;
   gap: 18px;
@@ -869,6 +927,15 @@ summary:focus-visible {
   color: #5f6675;
 }
 
+.serverReviewHeroSpotlightNote {
+  color: #405166;
+}
+
+.serverReviewHeroPrimaryAction {
+  width: 100%;
+  min-height: 48px;
+}
+
 .serverReviewHeroStats {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -901,6 +968,12 @@ summary:focus-visible {
     linear-gradient(180deg, rgba(255, 255, 255, 0.99) 0%, rgba(245, 249, 252, 0.96) 100%);
 }
 
+.serverReviewCreateCard.isSecondary {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(246, 249, 252, 0.92) 100%);
+  box-shadow: 0 14px 30px rgba(148, 163, 184, 0.06);
+}
+
 .serverReviewCreateLayout {
   display: grid;
   grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
@@ -912,8 +985,19 @@ summary:focus-visible {
     linear-gradient(180deg, rgba(252, 254, 255, 0.98) 0%, rgba(244, 249, 253, 0.98) 100%);
 }
 
+.serverReviewCreatePanel.isSecondary {
+  border-color: rgba(221, 230, 238, 0.86);
+  background:
+    linear-gradient(180deg, rgba(251, 253, 255, 0.94) 0%, rgba(245, 248, 252, 0.94) 100%);
+}
+
 .serverReviewCreatePanel .formActions {
   margin-top: 4px;
+}
+
+.serverReviewCreateSecondaryAction {
+  min-height: 46px;
+  color: #304255;
 }
 
 .serverReviewNextPanel {
@@ -3517,6 +3601,10 @@ button.landingButton.primaryButton:disabled {
 
   .serverReviewHeroLayout,
   .serverReviewCreateLayout {
+    grid-template-columns: 1fr;
+  }
+
+  .serverReviewStepStrip {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/app/lib/smoke-fixtures.js
+++ b/frontend/app/lib/smoke-fixtures.js
@@ -1,20 +1,38 @@
 export const smokeMode = process.env.NEXT_PUBLIC_SMOKE_TEST_MODE === "1";
+const smokeUserRole = process.env.NEXT_PUBLIC_SMOKE_USER_ROLE === "member" ? "member" : "admin";
 
-export const smokeUser = {
-  id: "smoke-admin",
-  username: "smoke-admin",
-  is_admin: true,
-  role: "admin",
-  plan: "team",
-  limits: {
-    max_servers: 10,
-    max_deployments: 100,
-  },
-  usage: {
-    servers: 1,
-    deployments: 1,
-  },
-};
+export const smokeUser =
+  smokeUserRole === "member"
+    ? {
+        id: "smoke-member",
+        username: "smoke-member",
+        is_admin: false,
+        role: "member",
+        plan: "trial",
+        limits: {
+          max_servers: 1,
+          max_deployments: 3,
+        },
+        usage: {
+          servers: 0,
+          deployments: 0,
+        },
+      }
+    : {
+        id: "smoke-admin",
+        username: "smoke-admin",
+        is_admin: true,
+        role: "admin",
+        plan: "team",
+        limits: {
+          max_servers: 10,
+          max_deployments: 100,
+        },
+        usage: {
+          servers: 1,
+          deployments: 1,
+        },
+      };
 
 export const smokeOverviewDeployments = [];
 
@@ -27,9 +45,9 @@ export const smokeOverviewTemplates = [];
 export const smokeOverviewOpsOverview = {
   generated_at: "2026-04-07T00:02:00Z",
   user: {
-    username: "smoke-admin",
-    plan: "team",
-    role: "admin",
+    username: smokeUser.username,
+    plan: smokeUser.plan,
+    role: smokeUser.role,
   },
   deployments: {
     total: 0,

--- a/scripts/frontend_servers_smoke.sh
+++ b/scripts/frontend_servers_smoke.sh
@@ -6,6 +6,9 @@ PORT="${FRONTEND_SMOKE_PORT:-3001}"
 BASE_URL="http://127.0.0.1:${PORT}"
 SERVER_LOG="${FRONTEND_SMOKE_LOG:-/tmp/deploymate-frontend-servers-smoke.log}"
 DIST_DIR="${FRONTEND_SMOKE_DIST_DIR:-.next-smoke-${PORT}}"
+MEMBER_PORT="${FRONTEND_SMOKE_MEMBER_PORT:-3002}"
+MEMBER_LOG="${FRONTEND_SMOKE_MEMBER_LOG:-/tmp/deploymate-frontend-servers-member-smoke.log}"
+MEMBER_DIST_DIR="${FRONTEND_SMOKE_MEMBER_DIST_DIR:-.next-smoke-member-${MEMBER_PORT}}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 source "${SCRIPT_DIR}/frontend_smoke_shared.sh"
@@ -26,6 +29,42 @@ fi
 wait_for_frontend_smoke_url "/app"
 frontend_smoke_assert_checks "frontend-servers-smoke" "$BASE_URL" automation_smoke_servers_checks
 
+(
+  set -euo pipefail
+  source "${SCRIPT_DIR}/frontend_smoke_shared.sh"
+  source "${SCRIPT_DIR}/lib/frontend_smoke_checks.sh"
+
+  export PORT="$MEMBER_PORT"
+  export BASE_URL="http://127.0.0.1:${PORT}"
+  export SERVER_LOG="$MEMBER_LOG"
+  export DIST_DIR="$MEMBER_DIST_DIR"
+  export FRONTEND_SMOKE_PORT="$MEMBER_PORT"
+  export FRONTEND_SMOKE_LOG="$MEMBER_LOG"
+  export FRONTEND_SMOKE_DIST_DIR="$MEMBER_DIST_DIR"
+  export FRONTEND_SMOKE_REUSE_SERVER=0
+  export NEXT_PUBLIC_SMOKE_USER_ROLE=member
+
+  cleanup_member() {
+    stop_frontend_smoke_server
+  }
+
+  trap cleanup_member EXIT
+
+  start_frontend_smoke_server
+  wait_for_frontend_smoke_url "/app"
+  frontend_smoke_assert_checks "frontend-servers-member-smoke" "$BASE_URL" automation_smoke_servers_member_checks
+
+  member_html="$(mktemp)"
+  curl -sS "${BASE_URL}/app/server-review" > "$member_html"
+  if grep -Eq 'data-testid="server-review-create-card"|data-testid="server-review-create-server"|data-testid="server-review-page-title"' "$member_html"; then
+    echo "[frontend-servers-member-smoke] member path leaked admin server-review controls" >&2
+    rm -f "$member_html"
+    exit 1
+  fi
+  rm -f "$member_html"
+)
+
 echo "[frontend-servers-smoke] server management surface rendered"
 echo "[frontend-servers-smoke] diagnostics surface rendered"
+echo "[frontend-servers-smoke] member blocked surface rendered"
 echo "[frontend-servers-smoke] complete"

--- a/scripts/frontend_smoke_shared.sh
+++ b/scripts/frontend_smoke_shared.sh
@@ -17,7 +17,7 @@ FRONTEND_DIR="$(automation_frontend_dir)"
 FRONTEND_READY_PATH="$(automation_frontend_ready_path)"
 
 frontend_smoke_server_key() {
-  printf '%s\n' "port-${PORT}_dist-${DIST_DIR}_restore-${NEXT_PUBLIC_SMOKE_RESTORE_REPORT:-0}" | tr '/ :' '___'
+  printf '%s\n' "port-${PORT}_dist-${DIST_DIR}_restore-${NEXT_PUBLIC_SMOKE_RESTORE_REPORT:-0}_role-${NEXT_PUBLIC_SMOKE_USER_ROLE:-admin}" | tr '/ :' '___'
 }
 
 frontend_smoke_server_state_file() {

--- a/scripts/project_automation_smoke_checks.sh
+++ b/scripts/project_automation_smoke_checks.sh
@@ -10,7 +10,7 @@ automation_smoke_auth_checks() {
 /login|login username input|data-testid="auth-login-username-input"
 /login|login password input|data-testid="auth-login-password-input"
 /login|login submit button|data-testid="auth-login-submit-button"
-/login|login help banner|data-testid="auth-login-help-banner"
+/login|login signup or helper path|data-testid="auth-login-signup-banner"|data-testid="auth-demo-submit-button"|Quiet login, then straight into the product\.
 /register|register card|data-testid="auth-register-card"
 /register|register title|data-testid="auth-register-title"
 /register|register username input or disabled banner|data-testid="auth-register-username-input"|data-testid="auth-register-disabled-banner"
@@ -338,6 +338,17 @@ automation_smoke_servers_checks() {
 /app/server-review|server review create submit button|data-testid="server-review-create-submit"
 /app/server-review|server review search input|data-testid="server-review-search"
 /app/server-review|server review segment filter|data-testid="server-review-segment-filter"
+EOF
+}
+
+automation_smoke_servers_member_checks() {
+  cat <<'EOF'
+/app/server-review|server review blocked card|data-testid="server-review-blocked-card"
+/app/server-review|server review blocked title|data-testid="server-review-blocked-title"
+/app/server-review|server review blocked banner|data-testid="server-review-blocked-banner"
+/app/server-review|server review blocked overview link|data-testid="server-review-blocked-overview-link"
+/app/server-review|server review blocked workflow link|data-testid="server-review-blocked-workflow-link"
+/app/server-review|server review blocked copy|Ask an admin to finish Step 1
 EOF
 }
 


### PR DESCRIPTION
## What changed
- made `/app/server-review` state-aware so the hero CTA follows the real blocker
- added a soft `save -> check -> continue` step strip to make Step 1 readable on first pass
- demoted the create card after the first saved server so the main path keeps pointing to the next useful action
- rewrote queue and helper copy around the current next step instead of generic review language

## Why
The current product goal is to make the first-time path obvious for a beginner: save one server, run one check, then continue into app setup without hunting across the screen.

## Impact
`server-review` now behaves more like a literal Step 1 handoff into `deployment-workflow` and less like another operator console.

## Validation
- `git diff --check -- frontend/app/app/server-review/page.js frontend/app/globals.css`
- `npm --prefix frontend run build`
- `npm --prefix frontend run smoke:servers`