### PR TITLE
[codex] Restore login help banner for auth smoke

### DIFF
--- a/frontend/app/login/page.js
+++ b/frontend/app/login/page.js
@@ -104,6 +104,18 @@ export default async function LoginPage({ searchParams }) {
 
             {error ? <div className="banner error" data-testid="auth-login-error-banner">{error}</div> : null}
 
+            <div className="banner subtle authBanner" data-testid="auth-login-help-banner">
+              {publicSignupEnabled ? (
+                <>
+                  Use your workspace username and password, or start with a trial account below if you are new here.
+                </>
+              ) : (
+                <>
+                  Use the username and password your admin gave you to open the workspace.
+                </>
+              )}
+            </div>
+
             {publicSignupEnabled ? (
               <div className="banner subtle authBanner" data-testid="auth-login-signup-banner">
                 Need a trial account?{" "}


### PR DESCRIPTION
## What changed
- restored a persistent login help banner with the expected `auth-login-help-banner` test id
- kept the copy state-aware so it still reads correctly when public signup is enabled or disabled

## Why
`frontend_auth_smoke` and the PR release gate currently fail because the login screen no longer renders the expected help banner.

## Impact
This makes the auth smoke contract explicit again and should unblock PRs that are currently red for the same login-screen check.

## Validation
- `git diff --check -- frontend/app/login/page.js`
- `npm --prefix frontend run build`
- `FRONTEND_SMOKE_REUSE_SERVER=1 FRONTEND_SMOKE_PORT=3001 npm --prefix frontend run smoke:auth`