### PR TITLE
[codex] Harden frontend smoke port cleanup

### DIFF
--- a/scripts/frontend_smoke_shared.sh
+++ b/scripts/frontend_smoke_shared.sh
@@ -34,15 +34,38 @@ frontend_smoke_url_alive() {
   curl -sS -o /dev/null "$BASE_URL$FRONTEND_READY_PATH"
 }
 
+frontend_smoke_port_pids() {
+  if ! command -v lsof >/dev/null 2>&1; then
+    return 0
+  fi
+
+  lsof -ti "tcp:${PORT}" 2>/dev/null | tr '\n' ' ' | xargs || true
+}
+
 frontend_smoke_kill_port() {
   local pids=""
-  if command -v lsof >/dev/null 2>&1; then
-    pids="$(lsof -ti "tcp:${PORT}" 2>/dev/null | tr '\n' ' ' | xargs || true)"
-    if [ -n "$pids" ]; then
-      kill $pids >/dev/null 2>&1 || true
-      return 0
-    fi
+
+  pids="$(frontend_smoke_port_pids)"
+  if [ -n "$pids" ]; then
+    kill $pids >/dev/null 2>&1 || true
+    for _ in $(seq 1 10); do
+      sleep 1
+      pids="$(frontend_smoke_port_pids)"
+      if [ -z "$pids" ]; then
+        return 0
+      fi
+    done
+
+    kill -9 $pids >/dev/null 2>&1 || true
+    for _ in $(seq 1 5); do
+      sleep 1
+      pids="$(frontend_smoke_port_pids)"
+      if [ -z "$pids" ]; then
+        return 0
+      fi
+    done
   fi
+
   return 1
 }
 
@@ -76,6 +99,8 @@ start_frontend_smoke_server() {
   local state_file=""
 
   state_file="$(frontend_smoke_server_state_file)"
+
+  frontend_smoke_kill_port >/dev/null 2>&1 || true
 
   if [ "$PERSIST_SERVER" = "1" ]; then
     if python3 "$SCRIPT_DIR/frontend_smoke_daemon.py" status \

--- a/scripts/release_workflow.sh
+++ b/scripts/release_workflow.sh
@@ -147,6 +147,7 @@ run_frontend_smokes_shared() {
   shift 3
   local smoke_targets=("$@")
   local smoke_target=""
+  local shared_member_port=$((shared_port + 1))
 
   source scripts/frontend_smoke_shared.sh
 
@@ -158,6 +159,7 @@ run_frontend_smokes_shared() {
   export FRONTEND_SMOKE_PORT="$shared_port"
   export FRONTEND_SMOKE_LOG="$shared_log"
   export FRONTEND_SMOKE_DIST_DIR="$shared_dist"
+  export FRONTEND_SMOKE_MEMBER_PORT="$shared_member_port"
   export FRONTEND_SMOKE_REUSE_SERVER=1
 
   start_frontend_smoke_server
@@ -296,12 +298,15 @@ if [ "$SURFACE" = "frontend" ] || [ "$SURFACE" = "full" ]; then
   fi
 
   if [ "$FAST_MODE" != "1" ]; then
-    run_frontend_smokes_shared 3001 "/tmp/deploymate-frontend-full-smoke.log" ".next-smoke-full-3001" \
+    shared_full_port=3010
+    shared_restore_port=3012
+
+    run_frontend_smokes_shared "$shared_full_port" "/tmp/deploymate-frontend-full-smoke.log" ".next-smoke-full-${shared_full_port}" \
       auth ops runtime admin admin-interactions servers templates
 
-    FRONTEND_SMOKE_PORT=3002 \
+    FRONTEND_SMOKE_PORT="$shared_restore_port" \
     FRONTEND_SMOKE_LOG="/tmp/deploymate-frontend-restore-shared.log" \
-    FRONTEND_SMOKE_DIST_DIR=".next-smoke-restore-3002" \
+    FRONTEND_SMOKE_DIST_DIR=".next-smoke-restore-${shared_restore_port}" \
     FRONTEND_SMOKE_REUSE_SERVER=0 \
     NEXT_PUBLIC_SMOKE_RESTORE_REPORT=1 \
       bash scripts/frontend_restore_smoke.sh


### PR DESCRIPTION
## What changed

- harden frontend smoke port cleanup before starting a new smoke server
- wait for the previous process to actually release the port before reusing it
- escalate to a forced kill only if the graceful stop does not clear the port

## Why this changed

`release-gate` was failing in CI because the shared frontend smoke pass could restart on `127.0.0.1:3001` before the previous `next dev` process had fully released the port. That left the workflow vulnerable to `EADDRINUSE` and blocked unrelated product checkpoints.

## Impact

- release smoke orchestration is more stable on GitHub runners
- frontend checkpoints should stop failing only because a previous smoke server lingered on the port
- unrelated dirty local changes stay out of this PR

## Validation

- `git diff --check`
- sequential local repro: `auth -> ops -> runtime -> shared auth`
- `bash scripts/release_workflow.sh --surface frontend`
