### PR TITLE
[codex] Soften deployment workflow step-two guidance

### DIFF
--- a/frontend/app/app/deployment-workflow/page.js
+++ b/frontend/app/app/deployment-workflow/page.js
@@ -194,13 +194,21 @@ function DeploymentWorkflowPageContent() {
           : "This page is where you choose one app image and start it.";
   const workflowPrimaryMode = workflowState.mode === "live" ? "live" : "create";
   const workflowPrimaryAction = serverAccessBlocked
-    ? {
-        title: "Server target is admin-managed",
-        detail:
-          "Members cannot pick saved server targets here. Ask an admin to confirm the target, then come back to the deployment workflow.",
-        href: "/app",
-        actionLabel: "Back to overview",
-      }
+    ? filteredDeployments.length > 0
+      ? {
+          title: "Review the live deployments first",
+          detail:
+            "Admins still manage the saved target, but this page can already help you review what is running before the next rollout is unlocked.",
+          href: "#runtime-deployments",
+          actionLabel: "Open live deployments",
+        }
+      : {
+          title: "Server target is admin-managed",
+          detail:
+            "Members cannot pick saved server targets here. Ask an admin to confirm the target, then come back to the deployment workflow.",
+          href: "/app",
+          actionLabel: "Back to overview",
+        }
     : {
         title: workflowState.title,
         detail: workflowState.detail,
@@ -1276,8 +1284,135 @@ function DeploymentWorkflowPageContent() {
           primaryAction: "Back to overview",
           secondaryAction: "Copy next step",
           tone: "warn",
-        }
+      }
     : workflowNextStep;
+  const workflowHeroSpotlight = waitingForAdminTarget
+    ? {
+        badge: "Waiting on admin",
+        title: "Wait for one confirmed target",
+        detail:
+          "This page should explain what opens next, not push you into rollout settings before a usable server target exists.",
+        support:
+          "As soon as one admin-managed target is confirmed, Step 2 becomes a simpler choice: pick one app, start it, then check health.",
+      }
+    : serverAccessBlocked
+      ? filteredDeployments.length > 0
+        ? {
+            badge: "Live review stays open",
+            title: "Use the runtime lane while admins manage the target",
+            detail:
+              "You cannot pick a saved target here, but you can still review the deployments that already exist and remove uncertainty there first.",
+            support:
+              "Treat create and template work as background until the target is confirmed or the live runtime is understood.",
+          }
+        : {
+            badge: "Waiting on admin",
+            title: "Ask for one confirmed target before rollout creation",
+            detail:
+              "Without one saved target, this page should only point toward the next unblock instead of pretending rollout creation is already ready.",
+            support:
+              "Once the target is confirmed, this workspace becomes the main place to choose what app should run next.",
+          }
+      : workflowState.mode === "prerequisite"
+        ? {
+            badge: "Finish Step 1",
+            title: "Connect one server before Step 2 takes over",
+            detail:
+              "This workspace becomes useful right after one target is saved and checked in Server Review.",
+            support:
+              "Do not split attention between rollout settings and server setup. Let Step 1 finish first, then come back here.",
+          }
+        : workflowState.mode === "live"
+          ? {
+              badge: "Needs attention",
+              title: "Review the live queue before another rollout",
+              detail:
+                "A deployment already needs review, so the safest move is understanding the runtime before you change anything else.",
+              support:
+                "Keep create and template reuse visible, but quieter than the current incident path.",
+            }
+          : templates.length > 0
+            ? {
+                badge: deployments.length === 0 ? "Step 1 complete" : "Keep momentum",
+                title: "Choose one app or reuse one saved setup",
+                detail:
+                  "This is the shortest route now: open one lane, finish that rollout step, then check health before you make another change.",
+                support:
+                  "If this deploy is brand new, start with the image form. If it is repeatable, let a template save time without reopening extra admin surfaces.",
+              }
+            : {
+                badge: deployments.length === 0 ? "Step 1 complete" : "Do this now",
+                title: "Choose the next app to run",
+                detail:
+                  "Stay inside one guided form so image, target, ports, env vars, and launch all read like one continuous task.",
+                support:
+                  "Advanced fields are still here, but they should stay quieter than the decision to start one deliberate rollout.",
+              };
+  const workflowServerStepState =
+    waitingForAdminTarget || workflowState.mode === "prerequisite" ? "current" : "complete";
+  const workflowLaunchStepState =
+    waitingForAdminTarget || workflowState.mode === "prerequisite"
+      ? "upcoming"
+      : workflowState.mode === "live"
+        ? "complete"
+        : "current";
+  const workflowReviewStepState = workflowState.mode === "live" ? "current" : "upcoming";
+  const workflowStepCards = [
+    {
+      id: "server",
+      label: "1. Connect",
+      title: waitingForAdminTarget
+        ? "Wait for admin target"
+        : canAccessServers && !localDeploymentsEnabled
+          ? servers.length > 0
+            ? "Server step is ready"
+            : "Connect one server"
+          : localDeploymentsEnabled
+            ? "Server step is already covered"
+            : "Target stays with admins",
+      detail: waitingForAdminTarget
+        ? "Remote rollout opens after one confirmed saved target."
+        : canAccessServers && !localDeploymentsEnabled
+          ? servers.length > 0
+            ? "At least one remote target is already saved for this workflow."
+            : "Save one SSH target before rollout creation becomes the main path."
+          : localDeploymentsEnabled
+            ? "Local mode lets this workspace move straight into what to run."
+            : "Members rely on one admin-confirmed target before remote rollout.",
+      state: workflowServerStepState,
+    },
+    {
+      id: "launch",
+      label: "2. Launch",
+      title:
+        workflowState.mode === "live"
+          ? "Choose the next rollout later"
+          : templates.length > 0
+            ? "Start from image or template"
+            : "Choose one app to run",
+      detail:
+        workflowState.mode === "live"
+          ? "Creation waits until the current runtime is understood."
+          : "Use one lane: blank form for new work, saved setup for repeat work.",
+      state: workflowLaunchStepState,
+    },
+    {
+      id: "review",
+      label: "3. Review",
+      title: workflowState.mode === "live" ? "Review the live issue" : "Check live health",
+      detail:
+        workflowState.mode === "live"
+          ? "This is the current step before another rollout."
+          : "After the app starts, confirm it is healthy before the next change.",
+      state: workflowReviewStepState,
+    },
+  ];
+  const workflowGuideTitle = waitingForAdminTarget
+    ? "What opens after the target is ready"
+    : "Keep Step 2 in one deliberate lane";
+  const workflowGuideBody = waitingForAdminTarget
+    ? "As soon as one target is confirmed, this page should feel simpler than it does now: choose the app, start it, then check health."
+    : "One lane should feel current. The other lanes should read like context, not like competing instructions.";
   const previewDiffRows = buildTemplateDiff(primaryTemplate, currentDraft, servers);
 
   if (!authChecked) {
@@ -1315,32 +1450,76 @@ function DeploymentWorkflowPageContent() {
   return (
     <main className="page">
       <div className="container">
-        <article className="card formCard">
-          <div className="header">
-            <div>
-              <div className="eyebrow">Step 2</div>
-              <h1 data-testid="deployment-workflow-title">Choose what to run</h1>
-              <p className="formHint">{stepTwoLead}</p>
-              <p className="formHint">{stepTwoSupport}</p>
+        <article className="card formCard workspaceHero deploymentWorkflowHero">
+          <div className="workspaceHeroBackdrop" />
+          <div className="deploymentWorkflowHeroLayout">
+            <div className="deploymentWorkflowHeroCopy">
+              <div className="header workspaceHeroHeader">
+                <div>
+                  <div className="eyebrow">Step 2</div>
+                  <h1 data-testid="deployment-workflow-title">Choose what to run</h1>
+                  <p className="deploymentWorkflowLead">{stepTwoLead}</p>
+                  <p className="formHint deploymentWorkflowSubtleCopy">{stepTwoSupport}</p>
+                </div>
+                <div className="buttonRow workspaceHeroActions deploymentWorkflowHeroActions">
+                  {canAccessServers ? (
+                    <Link href="/app/server-review" className="linkButton">
+                      Back to server step
+                    </Link>
+                  ) : (
+                    <Link href="/app" className="linkButton">
+                      Overview
+                    </Link>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => refreshWorkspace()}
+                    disabled={loading || serversLoading || templatesLoading}
+                    className="secondaryButton"
+                  >
+                    {loading || serversLoading || templatesLoading ? "Refreshing..." : "Refresh"}
+                  </button>
+                </div>
+              </div>
+              <div className="deploymentWorkflowStepStrip" aria-label="Deployment workflow path">
+                {workflowStepCards.map((step) => (
+                  <article
+                    key={step.id}
+                    className={`deploymentWorkflowStepCard is${step.state[0].toUpperCase()}${step.state.slice(1)}`}
+                  >
+                    <span>{step.label}</span>
+                    <strong>{step.title}</strong>
+                    <p>{step.detail}</p>
+                  </article>
+                ))}
+              </div>
             </div>
-            <div className="buttonRow">
-              {canAccessServers ? (
-                <Link href="/app/server-review" className="linkButton">
-                  Back to server step
-                </Link>
-              ) : (
-                <Link href="/app" className="linkButton">
-                  Overview
-                </Link>
-              )}
-              <button
-                type="button"
-                onClick={() => refreshWorkspace()}
-                disabled={loading || serversLoading || templatesLoading}
-                className="secondaryButton"
-              >
-                {loading || serversLoading || templatesLoading ? "Refreshing..." : "Refresh"}
-              </button>
+            <div className="deploymentWorkflowHeroRail">
+              <article className="workspaceHeroBadge deploymentWorkflowHeroPanel">
+                <span>{workflowHeroSpotlight.badge}</span>
+                <strong>{workflowHeroSpotlight.title}</strong>
+                <p>{workflowHeroSpotlight.detail}</p>
+                <p className="workspaceHeroSpotlightNote">{workflowHeroSpotlight.support}</p>
+                <div className="formActions">
+                  <Link href={workflowPrimaryAction.href} className="landingButton primaryButton">
+                    {workflowPrimaryAction.actionLabel}
+                  </Link>
+                </div>
+                <div className="deploymentWorkflowHeroStats" aria-label="Deployment workflow summary">
+                  <div className="deploymentWorkflowHeroStat">
+                    <span>Running</span>
+                    <strong>{runningDeploymentCount}</strong>
+                  </div>
+                  <div className="deploymentWorkflowHeroStat">
+                    <span>Need review</span>
+                    <strong>{failedDeploymentCount}</strong>
+                  </div>
+                  <div className="deploymentWorkflowHeroStat">
+                    <span>Saved setups</span>
+                    <strong>{templates.length}</strong>
+                  </div>
+                </div>
+              </article>
             </div>
           </div>
         </article>
@@ -1453,224 +1632,174 @@ function DeploymentWorkflowPageContent() {
           </article>
         ) : null}
 
-        <article className="card formCard workspaceGuidePanel" data-testid="deployment-workflow-step-guide-card">
+        <article className="card formCard workspaceGuidePanel deploymentWorkflowGuidePanel" data-testid="deployment-workflow-step-guide-card">
           <div className="sectionHeader workspaceGuideHeader">
             <div>
-              <h2>How to use Step 2 without getting lost</h2>
+              <h2>{workflowGuideTitle}</h2>
               <p className="formHint">
-                This page can do a lot, but a beginner only needs one lane at a time: choose the app, start it, then check health.
+                {workflowGuideBody}
               </p>
             </div>
           </div>
-          <div className="workspaceReviewerGrid">
-            {stepTwoGuideCards.map((card) => (
-              <article key={card.label} className="workspaceReviewerCard">
-                <span>{card.label}</span>
-                <strong>{card.title}</strong>
-                <p>{card.detail}</p>
+          <div className="workspaceGuideGrid deploymentWorkflowGuideGrid">
+            <div className="workspaceGuideSteps">
+              <article
+                className="workspaceGlancePanel workspacePriorityPanel deploymentWorkflowPrimaryCard"
+                data-testid="deployment-workflow-primary-action-card"
+              >
+                <div className="workspaceGlanceHeader">
+                  <span className="eyebrow">{workflowHeroSpotlight.badge}</span>
+                  <strong data-testid="deployment-workflow-primary-action-title">{workflowPrimaryAction.title}</strong>
+                </div>
+                <p className="formHint">{workflowPrimaryAction.detail}</p>
+                <p className="workspacePrioritySupport">{workflowHeroSpotlight.support}</p>
+                <div className="formActions">
+                  <Link href={workflowPrimaryAction.href} className="landingButton primaryButton">
+                    {workflowPrimaryAction.actionLabel}
+                  </Link>
+                </div>
               </article>
-            ))}
-          </div>
-        </article>
-
-        <article className="card formCard workspaceGuidePanel" data-testid="deployment-workflow-primary-action-card">
-          <div className="sectionHeader workspaceGuideHeader">
-            <div>
-              <h2 data-testid="deployment-workflow-primary-action-title">Do this now</h2>
-              <p className="formHint">
-                {workflowPrimaryAction.detail} Pick one lane below, finish that job, and ignore the other lanes until the next decision is obvious.
-              </p>
+              <div className="workspaceReviewerGrid deploymentWorkflowGuideCards">
+                {stepTwoGuideCards.map((card) => (
+                  <article key={card.label} className="workspaceReviewerCard">
+                    <span>{card.label}</span>
+                    <strong>{card.title}</strong>
+                    <p>{card.detail}</p>
+                  </article>
+                ))}
+              </div>
             </div>
-          </div>
-          <div className="workspaceReviewerGrid">
-            {serverAccessBlocked ? (
-              <>
-                <article className="workspaceReviewerCard">
-                  <span>Do this now</span>
-                  <strong>{workflowPrimaryAction.actionLabel}</strong>
-                  <p>
-                    Saved server targets stay with admins, so the main task is confirming the target before a remote rollout can happen.
-                  </p>
-                  <Link href={workflowPrimaryAction.href} className="landingButton primaryButton">
-                    {workflowPrimaryAction.actionLabel}
-                  </Link>
-                </article>
-                <article className="workspaceReviewerCard">
-                  <span>{filteredDeployments.length > 0 ? "Still available" : "What unlocks next"}</span>
-                  <strong>
-                    {filteredDeployments.length > 0
-                      ? "You can still review live apps"
-                      : "Step 2 becomes simple after the target is ready"}
-                  </strong>
-                  <p>
-                    {filteredDeployments.length > 0
-                      ? "Even while admins manage the saved target, this page can still be used to inspect what is already running."
-                      : "Once one server target is confirmed, this page becomes a clean three-part path: choose one app, start it, then check health."}
-                  </p>
-                  {filteredDeployments.length > 0 ? (
-                    <button
-                      type="button"
-                      className="secondaryButton"
-                      onClick={() => setWorkflowTab("live")}
-                    >
-                      Open live apps
-                    </button>
-                  ) : null}
-                </article>
-              </>
-            ) : (
-              <>
-                <article className="workspaceReviewerCard">
-                  <span>Do this now</span>
-                  <strong>{workflowPrimaryAction.actionLabel}</strong>
-                  <p>
-                    {workflowState.mode === "prerequisite"
-                      ? "This workspace is ready for rollout work, but the remote-only prerequisite still comes first."
-                      : workflowPrimaryMode === "live"
-                        ? "A rollout already needs attention, so open the live lane before you create anything new."
-                        : "Use one guided form for the next app instead of scanning every part of the workspace."}
-                  </p>
-                  <Link href={workflowPrimaryAction.href} className="landingButton primaryButton">
-                    {workflowPrimaryAction.actionLabel}
-                  </Link>
-                </article>
-                <article className="workspaceReviewerCard">
-                  <span>Core lanes</span>
-                  <strong>Use one lane at a time</strong>
-                  <p>
-                    These are the only three lanes that matter here. Keep one of them active and treat the others as background.
-                  </p>
-                  <div
-                    className="filterTabs"
-                    role="tablist"
-                    aria-label="Deployment workflow tabs"
-                    data-testid="deployment-workflow-tabs-card"
-                  >
-                    <button
-                      type="button"
-                      className={workflowTab === "live" ? "active" : ""}
-                      onClick={() => setWorkflowTab("live")}
-                      data-testid="deployment-workflow-tab-live"
-                    >
-                      Check live apps
-                    </button>
-                    <button
-                      type="button"
-                      className={workflowTab === "create" ? "active" : ""}
-                      onClick={() => setWorkflowTab("create")}
-                      data-testid="deployment-workflow-tab-create"
-                    >
-                      Start app
-                    </button>
-                    <button
-                      type="button"
-                      className={workflowTab === "templates" ? "active" : ""}
-                      onClick={() => setWorkflowTab("templates")}
-                      data-testid="deployment-workflow-tab-templates"
-                    >
-                      Use saved setup
-                    </button>
-                  </div>
-                </article>
-              </>
-            )}
-          </div>
-        </article>
-
-        <article className="card formCard" data-testid="deployment-workflow-main-next-step-card">
-          <div className="sectionHeader">
-            <div>
-              <h2 data-testid="deployment-workflow-main-next-step-title">Your next task on this page</h2>
-              <p className="formHint">
-                If you are new here, trust this summary and let it choose the active lane for you.
-              </p>
-            </div>
-          </div>
-          <div className="row">
-            <span className="label">Current focus</span>
-            <span data-testid="deployment-workflow-main-next-step-focus">{memberWorkflowNextStep.focus}</span>
-          </div>
-          <div className="row">
-            <span className="label">What to do</span>
-            <span data-testid="deployment-workflow-main-next-step-copy">{memberWorkflowNextStep.nextStep}</span>
-          </div>
-          <div className="backupSummaryBadges">
-            <span className={`status ${memberWorkflowNextStep.tone}`}>filtered {filteredDeployments.length}</span>
-            <span className="status healthy">running {runningDeploymentCount}</span>
-            <span className="status error">failed {failedDeploymentCount}</span>
-            <span className="status info">templates {templates.length}</span>
-          </div>
-          <div className="actionCluster">
-            {serverAccessBlocked && filteredDeployments.length === 0 ? (
-              <Link
-                href="/app"
-                className="landingButton primaryButton"
-                data-testid="deployment-workflow-main-next-step-button"
-              >
-                Back to overview
-              </Link>
-            ) : serverAccessBlocked ? (
-              <button
-                type="button"
-                className="landingButton primaryButton"
-                data-testid="deployment-workflow-main-next-step-button"
-                onClick={() => setWorkflowTab("live")}
-              >
-                Open live deployments
-              </button>
-            ) : workflowState.mode === "prerequisite" ? (
-              <Link
-                href="/app/server-review"
-                className="landingButton primaryButton"
-                data-testid="deployment-workflow-main-next-step-button"
-              >
-                Open server review
-              </Link>
-            ) : failedDeploymentCount > 0 ? (
-              <button
-                type="button"
-                className="landingButton primaryButton"
-                data-testid="deployment-workflow-main-next-step-button"
-                onClick={() => setWorkflowTab("live")}
-              >
-                Open live deployments
-              </button>
-            ) : memberWorkflowNextStep.primaryAction === "Open templates" ? (
-              <button
-                type="button"
-                className="landingButton primaryButton"
-                data-testid="deployment-workflow-main-next-step-button"
-                onClick={() => setWorkflowTab("templates")}
-              >
-                Open templates
-              </button>
-            ) : memberWorkflowNextStep.primaryAction === "Fix the create form" ? (
-              <button
-                type="button"
-                className="landingButton primaryButton"
-                data-testid="deployment-workflow-main-next-step-button"
-                onClick={() => setWorkflowTab("create")}
-              >
-                Fix the create form
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="landingButton primaryButton"
-                data-testid="deployment-workflow-main-next-step-button"
-                onClick={() => setWorkflowTab("create")}
-              >
-                Create deployment
-              </button>
-            )}
-            <button
-              type="button"
-              className="secondaryButton"
-              data-testid="deployment-workflow-main-next-step-copy-button"
-              onClick={handleCopyNextStep}
+            <aside
+              className="workspaceGlancePanel deploymentWorkflowGuideAside"
+              data-testid="deployment-workflow-main-next-step-card"
             >
-              Copy next step
-            </button>
+              <div className="workspaceGlanceHeader">
+                <span className="eyebrow">Your current lane</span>
+                <strong data-testid="deployment-workflow-main-next-step-title">Your next task on this page</strong>
+              </div>
+              <p className="formHint">
+                Trust this summary first. The other lanes should read like backup, not like competing instructions.
+              </p>
+              <div className="row">
+                <span className="label">Current focus</span>
+                <span data-testid="deployment-workflow-main-next-step-focus">{memberWorkflowNextStep.focus}</span>
+              </div>
+              <div className="row">
+                <span className="label">What to do</span>
+                <span data-testid="deployment-workflow-main-next-step-copy">{memberWorkflowNextStep.nextStep}</span>
+              </div>
+              <div className="backupSummaryBadges">
+                <span className={`status ${memberWorkflowNextStep.tone}`}>filtered {filteredDeployments.length}</span>
+                <span className="status healthy">running {runningDeploymentCount}</span>
+                <span className="status error">failed {failedDeploymentCount}</span>
+                <span className="status info">templates {templates.length}</span>
+              </div>
+              {!serverAccessBlocked ? (
+                <div
+                  className="filterTabs deploymentWorkflowLaneTabs"
+                  role="tablist"
+                  aria-label="Deployment workflow tabs"
+                  data-testid="deployment-workflow-tabs-card"
+                >
+                  <button
+                    type="button"
+                    className={workflowTab === "live" ? "active" : ""}
+                    onClick={() => setWorkflowTab("live")}
+                    data-testid="deployment-workflow-tab-live"
+                  >
+                    Check live apps
+                  </button>
+                  <button
+                    type="button"
+                    className={workflowTab === "create" ? "active" : ""}
+                    onClick={() => setWorkflowTab("create")}
+                    data-testid="deployment-workflow-tab-create"
+                  >
+                    Start app
+                  </button>
+                  <button
+                    type="button"
+                    className={workflowTab === "templates" ? "active" : ""}
+                    onClick={() => setWorkflowTab("templates")}
+                    data-testid="deployment-workflow-tab-templates"
+                  >
+                    Use saved setup
+                  </button>
+                </div>
+              ) : null}
+              <div className="actionCluster">
+                {serverAccessBlocked && filteredDeployments.length === 0 ? (
+                  <Link
+                    href="/app"
+                    className="landingButton primaryButton"
+                    data-testid="deployment-workflow-main-next-step-button"
+                  >
+                    Back to overview
+                  </Link>
+                ) : serverAccessBlocked ? (
+                  <button
+                    type="button"
+                    className="landingButton primaryButton"
+                    data-testid="deployment-workflow-main-next-step-button"
+                    onClick={() => setWorkflowTab("live")}
+                  >
+                    Open live deployments
+                  </button>
+                ) : workflowState.mode === "prerequisite" ? (
+                  <Link
+                    href="/app/server-review"
+                    className="landingButton primaryButton"
+                    data-testid="deployment-workflow-main-next-step-button"
+                  >
+                    Open server review
+                  </Link>
+                ) : failedDeploymentCount > 0 ? (
+                  <button
+                    type="button"
+                    className="landingButton primaryButton"
+                    data-testid="deployment-workflow-main-next-step-button"
+                    onClick={() => setWorkflowTab("live")}
+                  >
+                    Open live deployments
+                  </button>
+                ) : memberWorkflowNextStep.primaryAction === "Open templates" ? (
+                  <button
+                    type="button"
+                    className="landingButton primaryButton"
+                    data-testid="deployment-workflow-main-next-step-button"
+                    onClick={() => setWorkflowTab("templates")}
+                  >
+                    Open templates
+                  </button>
+                ) : memberWorkflowNextStep.primaryAction === "Fix the create form" ? (
+                  <button
+                    type="button"
+                    className="landingButton primaryButton"
+                    data-testid="deployment-workflow-main-next-step-button"
+                    onClick={() => setWorkflowTab("create")}
+                  >
+                    Fix the create form
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="landingButton primaryButton"
+                    data-testid="deployment-workflow-main-next-step-button"
+                    onClick={() => setWorkflowTab("create")}
+                  >
+                    Create deployment
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="secondaryButton"
+                  data-testid="deployment-workflow-main-next-step-copy-button"
+                  onClick={handleCopyNextStep}
+                >
+                  Copy next step
+                </button>
+              </div>
+            </aside>
           </div>
         </article>
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1227,6 +1227,165 @@ summary:focus-visible {
   right: 0;
 }
 
+.deploymentWorkflowHero {
+  margin-bottom: 18px;
+}
+
+.deploymentWorkflowHeroLayout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 18px;
+}
+
+.deploymentWorkflowHeroCopy {
+  display: grid;
+  gap: 18px;
+}
+
+.deploymentWorkflowLead {
+  margin: 0;
+  color: #132238;
+  font-size: 20px;
+  line-height: 1.6;
+}
+
+.deploymentWorkflowSubtleCopy {
+  margin: 0;
+  color: #516175;
+  line-height: 1.65;
+}
+
+.deploymentWorkflowStepStrip {
+  display: grid;
+  gap: 12px;
+}
+
+.deploymentWorkflowStepCard {
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px;
+  border: 1px solid rgba(215, 226, 236, 0.92);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.74);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.deploymentWorkflowStepCard span {
+  color: #73849a;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.deploymentWorkflowStepCard strong {
+  color: #132238;
+  font-family: var(--font-display), sans-serif;
+  font-size: 21px;
+  letter-spacing: -0.03em;
+}
+
+.deploymentWorkflowStepCard p {
+  margin: 0;
+  color: #5f6675;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.deploymentWorkflowStepCard.isCurrent {
+  border-color: rgba(197, 166, 111, 0.74);
+  background:
+    linear-gradient(180deg, rgba(255, 250, 242, 0.96) 0%, rgba(250, 245, 236, 0.94) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.88),
+    0 18px 34px rgba(201, 147, 56, 0.1);
+}
+
+.deploymentWorkflowStepCard.isComplete {
+  border-color: rgba(191, 211, 204, 0.9);
+  background:
+    linear-gradient(180deg, rgba(245, 251, 248, 0.96) 0%, rgba(238, 247, 242, 0.94) 100%);
+}
+
+.deploymentWorkflowStepCard.isUpcoming {
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.deploymentWorkflowHeroRail {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
+.deploymentWorkflowHeroActions {
+  justify-content: flex-end;
+}
+
+.deploymentWorkflowHeroPanel {
+  gap: 10px;
+  border-color: rgba(214, 225, 235, 0.94);
+  background:
+    linear-gradient(180deg, rgba(255, 252, 246, 0.98) 0%, rgba(244, 249, 253, 0.98) 100%);
+  box-shadow: 0 20px 44px rgba(17, 24, 39, 0.07);
+}
+
+.deploymentWorkflowHeroStats {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.deploymentWorkflowHeroStat {
+  padding: 12px 14px;
+  border: 1px solid rgba(19, 34, 56, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+}
+
+.deploymentWorkflowHeroStat span {
+  display: block;
+  color: #6b7280;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.deploymentWorkflowHeroStat strong {
+  display: block;
+  margin-top: 8px;
+  color: #132238;
+  font-family: var(--font-display), sans-serif;
+  font-size: 28px;
+  letter-spacing: -0.05em;
+}
+
+.deploymentWorkflowGuidePanel {
+  overflow: hidden;
+}
+
+.deploymentWorkflowPrimaryCard {
+  border-color: rgba(214, 225, 235, 0.95);
+  background:
+    linear-gradient(180deg, rgba(255, 252, 246, 0.98) 0%, rgba(244, 249, 253, 0.98) 100%);
+}
+
+.deploymentWorkflowGuideCards {
+  margin-top: 16px;
+}
+
+.deploymentWorkflowGuideAside {
+  align-content: start;
+  border-color: rgba(214, 225, 235, 0.95);
+  background:
+    linear-gradient(180deg, rgba(248, 251, 254, 0.98) 0%, rgba(241, 246, 251, 0.98) 100%);
+}
+
+.deploymentWorkflowLaneTabs {
+  margin-top: 4px;
+}
+
 .inlineHelp {
   position: relative;
   display: inline-flex;
@@ -3726,23 +3885,25 @@ button.landingButton.primaryButton:disabled {
   }
 
   .serverReviewHeroLayout,
-  .serverReviewCreateLayout {
+  .serverReviewCreateLayout,
+  .deploymentWorkflowHeroLayout {
     grid-template-columns: 1fr;
   }
 
-  .serverReviewStepStrip {
-    grid-template-columns: 1fr;
-  }
-
+  .serverReviewStepStrip,
+  .deploymentWorkflowStepStrip,
   .overviewStepStrip {
     grid-template-columns: 1fr;
   }
+
   .serverReviewHeroActions,
+  .deploymentWorkflowHeroActions,
   .serverReviewToolbarHeader {
     justify-content: stretch;
   }
 
-  .serverReviewHeroStats {
+  .serverReviewHeroStats,
+  .deploymentWorkflowHeroStats {
     grid-template-columns: 1fr;
   }
 
@@ -3873,6 +4034,10 @@ button.landingButton.primaryButton:disabled {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
+  .deploymentWorkflowStepStrip {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .workspaceHeroSummary {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
@@ -3894,6 +4059,11 @@ button.landingButton.primaryButton:disabled {
 @media (min-width: 920px) {
   .landingHeroGrid {
     grid-template-columns: minmax(0, 1.05fr) minmax(360px, 0.95fr);
+  }
+
+  .deploymentWorkflowHeroLayout {
+    grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
+    align-items: start;
   }
 
   .showcaseScoreboard {


### PR DESCRIPTION
## What changed
- rebuilt `/app/deployment-workflow` around the same soft hero + spotlight rhythm already used on `/app` and `/app/server-review`
- added a Step 2 path strip (`connect -> launch -> review`) so the deployment workspace reads as part of the same beginner-first story
- collapsed the old duplicated onboarding layers into one quieter guide section with one dominant next action and a calmer side summary
- kept create, live review, and template lanes intact while making the currently active lane more obvious

## Why
`/app` and `server-review` were already speaking a softer, clearer product language, but Step 2 still felt heavier and more repetitive. The goal here was to make the deployment workflow feel like the same story instead of a separate admin surface.

## Impact
The deployment workflow now should read faster on first pass: what step this is, what the current lane is, and what to ignore until later.

## Validation
- `git diff --check -- frontend/app/app/deployment-workflow/page.js frontend/app/globals.css`
- `npm --prefix frontend run build`
- `bash scripts/release_workflow.sh --surface frontend`
