### PR TITLE
[codex] Soften runtime step-three review flow

### DIFF
--- a/frontend/app/app/deployment-workflow/page.js
+++ b/frontend/app/app/deployment-workflow/page.js
@@ -125,6 +125,8 @@ function DeploymentWorkflowPageContent() {
   });
   const runningDeploymentCount = deployments.filter((deployment) => deployment.status === "running").length;
   const failedDeploymentCount = deployments.filter((deployment) => deployment.status === "failed").length;
+  const filteredRunningDeploymentCount = filteredDeployments.filter((deployment) => deployment.status === "running").length;
+  const filteredReviewDeploymentCount = filteredDeployments.filter((deployment) => deployment.status !== "running").length;
   const normalizedTemplateQuery = templateQuery.trim().toLowerCase();
   const filteredTemplates = [...templates]
     .filter((template) => {
@@ -222,6 +224,119 @@ function DeploymentWorkflowPageContent() {
   const secondaryRuntimeDeployments = primaryRuntimeDeployment
     ? filteredDeployments.filter((deployment) => deployment.id !== primaryRuntimeDeployment.id)
     : [];
+  const primaryRuntimeUrl = primaryRuntimeDeployment
+    ? buildDeploymentUrl(primaryRuntimeDeployment)
+    : "";
+  const runtimeLaneSummary = primaryRuntimeDeployment
+    ? primaryRuntimeDeployment.status === "failed"
+      ? {
+          badge: "Needs review",
+          title: "Start with the failed runtime",
+          detail:
+            "A rollout already failed, so the safest move is opening that deployment detail before you think about another change.",
+          support:
+            "Treat the remaining queue as background until the current failure is concrete enough to explain.",
+          actionHref: `/deployments/${primaryRuntimeDeployment.id}`,
+          actionLabel: "Open deployment details",
+          tone: "error",
+          nextStep:
+            "Read the failing runtime first, then decide whether the next move is stability work or a deliberate redeploy.",
+        }
+      : {
+          badge: "Review this now",
+          title: "Confirm one live deployment stays healthy",
+          detail:
+            "Use one runtime as the current focus so status, health, and next actions stay easier to read.",
+          support:
+            "If the focus deployment still looks believable after review, the rest of the queue can stay quieter.",
+          actionHref: `/deployments/${primaryRuntimeDeployment.id}`,
+          actionLabel: "Open deployment details",
+          tone: "healthy",
+          nextStep:
+            "Check this deployment first, then return to the rest of the queue only if another runtime still needs attention.",
+        }
+    : filteredDeployments.length === 0 && deployments.length > 0
+      ? {
+          badge: "Nothing matches",
+          title: "Reset the live filters first",
+          detail:
+            "The live lane is empty only because the current filters or search hide the deployments that already exist.",
+          support:
+            "Clear the filters, pick one runtime to review, and keep the rest of the queue in the background again.",
+          actionHref: "",
+          actionLabel: "Clear live filters",
+          tone: "warn",
+          nextStep:
+            "Remove the search or filter that is hiding the queue, then focus one deployment instead of scanning the whole list.",
+        }
+      : {
+          badge: "Nothing is running",
+          title: "This lane becomes useful after the first launch",
+          detail:
+            "Step 3 is for checking whether a started app is healthy enough to keep. Right now there is no live runtime to review yet.",
+          support:
+            "Go back to the create lane, start one app, and then return here to confirm it behaves the way you expect.",
+          actionHref: "#create-deployment",
+          actionLabel: "Go to create lane",
+          tone: "warn",
+          nextStep:
+            "Launch one app first. After that, this lane becomes the place to review health and decide what to do next.",
+        };
+  const runtimeLaneGuideCards = primaryRuntimeDeployment
+    ? [
+        {
+          label: "Current focus",
+          title:
+            primaryRuntimeDeployment.container_name ||
+            primaryRuntimeDeployment.image ||
+            "This deployment",
+          detail:
+            primaryRuntimeDeployment.status === "failed"
+              ? "The current focus already failed, so it should explain the next move before the rest of the queue competes for attention."
+              : "Start with one live runtime and confirm whether it is healthy enough to keep before the rest of the queue gets louder.",
+        },
+        {
+          label: "Check next",
+          title: primaryRuntimeUrl ? "Open the runtime and verify the public path" : "Open the runtime and verify the internal state",
+          detail:
+            primaryRuntimeUrl
+              ? `The current endpoint is ${primaryRuntimeUrl}. Use deployment detail to review health, diagnostics, activity, and rollout change readiness together.`
+              : "This runtime has no public URL yet. Open deployment detail to review status, diagnostics, and the next safe action in one place.",
+        },
+        {
+          label: "Ignore for now",
+          title:
+            secondaryRuntimeDeployments.length > 0
+              ? `${secondaryRuntimeDeployments.length} more deployment${secondaryRuntimeDeployments.length === 1 ? "" : "s"} stay in the queue`
+              : "There is no extra queue pressure right now",
+          detail:
+            secondaryRuntimeDeployments.length > 0
+              ? "The remaining queue still matters, but it should not outrank the one runtime you are currently trying to understand."
+              : "Once this focused runtime is understood, the next move can stay deliberate instead of reactive.",
+        },
+      ]
+    : [
+        {
+          label: "Current focus",
+          title: filteredDeployments.length === 0 ? "Nothing is visible yet" : "No runtime is leading yet",
+          detail:
+            filteredDeployments.length === 0
+              ? "The current filter or search is hiding the queue, so there is no useful runtime to review until the list is visible again."
+              : "This lane becomes useful as soon as one deployment exists and can act as the current review target.",
+        },
+        {
+          label: "What unlocks next",
+          title: "One visible runtime makes the page simpler",
+          detail:
+            "As soon as one deployment is visible, Step 3 becomes about understanding that runtime first and leaving the rest of the queue quieter.",
+        },
+        {
+          label: "Ignore for now",
+          title: "Do not over-read the empty lane",
+          detail:
+            "If there is no visible live runtime, the right move is either clearing filters or launching the first app, not opening deeper review tools prematurely.",
+        },
+      ];
   const requestedTemplateId = searchParams.get("template") || "";
   const requestedTemplateAction = searchParams.get("template_action") || "preview";
   const requestedTemplateSource = searchParams.get("template_source") || "";
@@ -1852,6 +1967,91 @@ function DeploymentWorkflowPageContent() {
             </div>
           </div>
         </div>
+
+        <article className="card formCard workspaceGuidePanel runtimeLaneGuidePanel">
+          <div className="sectionHeader workspaceGuideHeader">
+            <div>
+              <h2>Use Step 3 to verify the rollout</h2>
+              <p className="formHint">
+                This lane should answer one question first: is one live runtime believable enough to keep, or does it still need review before another change?
+              </p>
+            </div>
+          </div>
+          <div className="workspaceGuideGrid">
+            <div className="runtimeLaneGuideStack">
+              <article className="workspaceGlancePanel workspacePriorityPanel runtimeLanePrimaryCard">
+                <div className="workspaceGlanceHeader">
+                  <span className="eyebrow">{runtimeLaneSummary.badge}</span>
+                  <strong>{runtimeLaneSummary.title}</strong>
+                </div>
+                <p className="formHint">{runtimeLaneSummary.detail}</p>
+                <p className="workspacePrioritySupport">{runtimeLaneSummary.support}</p>
+                <div className="actionCluster">
+                  {runtimeLaneSummary.actionHref ? (
+                    <Link href={runtimeLaneSummary.actionHref} className="landingButton primaryButton">
+                      {runtimeLaneSummary.actionLabel}
+                    </Link>
+                  ) : (
+                    <button
+                      type="button"
+                      className="landingButton primaryButton"
+                      onClick={() => {
+                        setDeploymentFilter("all");
+                        setDeploymentQuery("");
+                      }}
+                    >
+                      {runtimeLaneSummary.actionLabel}
+                    </button>
+                  )}
+                  {primaryRuntimeUrl ? (
+                    <a href={primaryRuntimeUrl} target="_blank" rel="noreferrer" className="secondaryButton">
+                      Open app
+                    </a>
+                  ) : null}
+                </div>
+              </article>
+              <div className="workspaceReviewerGrid runtimeLaneGuideCards">
+                {runtimeLaneGuideCards.map((card) => (
+                  <article key={card.label} className="workspaceReviewerCard">
+                    <span>{card.label}</span>
+                    <strong>{card.title}</strong>
+                    <p>{card.detail}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+            <aside className="workspaceGlancePanel runtimeLaneGuideAside">
+              <div className="workspaceGlanceHeader">
+                <span className="eyebrow">Live queue</span>
+                <strong>Current runtime posture</strong>
+              </div>
+                <div className="workspaceGlanceList">
+                  <div className="workspaceStatusCard workspaceGlanceItem">
+                    <span>Visible</span>
+                    <strong>{filteredDeployments.length}</strong>
+                    <p>Deployments currently visible in this lane.</p>
+                  </div>
+                  <div className="workspaceStatusCard workspaceGlanceItem">
+                    <span>Running</span>
+                    <strong>{filteredRunningDeploymentCount}</strong>
+                    <p>Visible runtimes that currently report a healthy running state.</p>
+                  </div>
+                  <div className="workspaceStatusCard workspaceGlanceItem">
+                    <span>Need review</span>
+                    <strong>{filteredReviewDeploymentCount}</strong>
+                    <p>Visible deployments whose current state still competes for attention.</p>
+                  </div>
+                </div>
+              <div className="overviewAttentionItem">
+                <div className="overviewAttentionHeader">
+                  <span className={`status ${runtimeLaneSummary.tone}`}>{runtimeLaneSummary.badge.toLowerCase()}</span>
+                  <strong>{runtimeLaneSummary.nextStep}</strong>
+                </div>
+                <p>{runtimeLaneSummary.support}</p>
+              </div>
+            </aside>
+          </div>
+        </article>
 
         <div className="list" data-testid="runtime-deployments-list">
           {loading && deployments.length === 0 ? (

--- a/frontend/app/deployments/[deploymentId]/page.js
+++ b/frontend/app/deployments/[deploymentId]/page.js
@@ -734,6 +734,86 @@ export default function DeploymentDetailsPage({ params }) {
     form,
     suggestedPorts,
   );
+  const recentFailureCount = diagnostics?.activity?.recent_failure_count || 0;
+  const runtimeReviewSignalCard =
+    deployment?.status === "failed"
+      ? {
+          title: "Deployment status is already failed",
+          detail:
+            deployment.error ||
+            "A failed runtime stays the strongest signal on this page until the cause is concrete enough to explain.",
+        }
+      : health?.status && health.status !== "healthy"
+        ? {
+            title: `Health is ${health.status}`,
+            detail:
+              health?.error ||
+              "Health is the strongest signal right now, so deeper tools stay in service of explaining it.",
+          }
+        : recentFailureCount > 0
+          ? {
+              title: `${recentFailureCount} recent failure event${recentFailureCount === 1 ? "" : "s"} still matter`,
+              detail:
+                "Diagnostics history still carries failure pressure, so the runtime should stay readable before another rollout becomes the main story.",
+            }
+          : attentionItems.length > 0
+            ? {
+                title: `${attentionItems.length} runtime warning${attentionItems.length === 1 ? "" : "s"} are still visible`,
+                detail:
+                  attentionItems[0]?.message ||
+                  "The runtime still has open warnings, even if the deployment is currently reachable.",
+              }
+            : {
+                title: "No active runtime warning is leading",
+                detail:
+                  "The runtime looks calm enough that redeploy, handoff, and deeper tools can stay deliberate instead of reactive.",
+              };
+  const runtimeReviewGuideCards = [
+    {
+      label: "Current focus",
+      title: runtimeDecisionState.focus,
+      detail: runtimeDecisionState.why,
+    },
+    {
+      label: "Signal leading",
+      title: runtimeReviewSignalCard.title,
+      detail: runtimeReviewSignalCard.detail,
+    },
+    {
+      label: "What opens next",
+      title: changeReadinessState.focus,
+      detail:
+        runtimeDecisionState.tone === "healthy"
+          ? changeReadinessState.nextStep
+          : "Keep change work secondary until this runtime is understood well enough to explain.",
+    },
+  ];
+  const runtimeReviewPostureItems = [
+    {
+      label: "Attention",
+      value: `${attentionItems.length}`,
+      detail:
+        attentionItems.length > 0
+          ? `${attentionItems.length} runtime warning${attentionItems.length === 1 ? "" : "s"} are still visible on this page.`
+          : "No visible runtime warnings are leading right now.",
+    },
+    {
+      label: "Recent failures",
+      value: `${recentFailureCount}`,
+      detail:
+        recentFailureCount > 0
+          ? "Diagnostics history still needs explanation before the next rollout should become the main story."
+          : "No recent failure events are currently leading the review.",
+    },
+    {
+      label: "Change draft",
+      value: changeReadinessState.label,
+      detail:
+        redeployChangeRows.length > 0
+          ? changeReadinessState.focus
+          : "No visible redeploy changes are queued yet.",
+    },
+  ];
   const redeployConfirmationTarget = deployment?.container_name || deployment?.id || "";
   const redeployConfirmationPhrase = buildReviewConfirmationPhrase(
     "redeploy",
@@ -1494,63 +1574,111 @@ export default function DeploymentDetailsPage({ params }) {
             </div>
           </article>
 
-          <article className="card formCard" data-testid="runtime-detail-decision-card">
-            <div className="sectionHeader">
+          <article className="card formCard workspaceGuidePanel runtimeDetailReviewPanel" data-testid="runtime-detail-decision-card">
+            <div className="sectionHeader workspaceGuideHeader">
               <div>
-                <h2 data-testid="runtime-detail-decision-title">Decision status</h2>
+                <h2 data-testid="runtime-detail-decision-title">Read the runtime in one pass</h2>
                 <p className="formHint">
-                  This layer answers the main question first: is the runtime blocked, still under review, or stable enough for a deliberate change.
+                  Use this layer to keep one runtime readable: understand what is leading, decide whether the page still belongs to review, and only then let rollout changes compete for attention.
                 </p>
               </div>
             </div>
-            <div className="row">
-              <span className="label">Current state</span>
-              <span className={`status ${runtimeDecisionState.tone}`} data-testid="runtime-detail-decision-state">
-                {runtimeDecisionState.label}
-              </span>
-            </div>
-            <div className="row">
-              <span className="label">Focus</span>
-              <span data-testid="runtime-detail-decision-focus">{runtimeDecisionState.focus}</span>
-            </div>
-            <div className="row">
-              <span className="label">Why</span>
-              <span data-testid="runtime-detail-decision-why">{runtimeDecisionState.why}</span>
-            </div>
-            <div className="row">
-              <span className="label">What to do</span>
-              <span data-testid="runtime-detail-decision-next-step">{runtimeDecisionState.nextStep}</span>
-            </div>
-            <div className="backupSummaryBadges">
-              {runtimeDecisionState.badges.map((badge) => (
-                <span key={badge.label} className={`status ${badge.tone}`}>
-                  {badge.label} {badge.value}
-                </span>
-              ))}
-            </div>
-            <div className="actionCluster">
-              <Link
-                href={runtimeDecisionState.primaryHref}
-                className="landingButton primaryButton"
-                data-testid="runtime-detail-decision-primary-action"
-              >
-                {runtimeDecisionState.primaryAction}
-              </Link>
-              <Link
-                href={runtimeDecisionState.secondaryHref}
-                className="secondaryButton"
-                data-testid="runtime-detail-decision-secondary-action"
-              >
-                {runtimeDecisionState.secondaryAction}
-              </Link>
-              <button
-                type="button"
-                className="secondaryButton"
-                data-testid="runtime-detail-decision-copy-button"
-                onClick={handleCopyRuntimeNextStep}
-              >
-                Copy next step
-              </button>
+            <div className="workspaceGuideGrid runtimeDetailReviewGrid">
+              <div className="runtimeDetailReviewStack">
+                <article className="workspaceGlancePanel workspacePriorityPanel runtimeDetailReviewPrimary">
+                  <div className="workspaceGlanceHeader">
+                    <span
+                      className={`status ${runtimeDecisionState.tone}`}
+                      data-testid="runtime-detail-decision-state"
+                    >
+                      {runtimeDecisionState.label}
+                    </span>
+                    <strong data-testid="runtime-detail-decision-focus">{runtimeDecisionState.focus}</strong>
+                  </div>
+                  <p className="formHint" data-testid="runtime-detail-decision-why">{runtimeDecisionState.why}</p>
+                  <p className="workspacePrioritySupport" data-testid="runtime-detail-decision-next-step">
+                    {runtimeDecisionState.nextStep}
+                  </p>
+                  <div className="backupSummaryBadges runtimeDetailDecisionBadges">
+                    {runtimeDecisionState.badges.map((badge) => (
+                      <span key={badge.label} className={`status ${badge.tone}`}>
+                        {badge.label} {badge.value}
+                      </span>
+                    ))}
+                    <span className={`status ${changeReadinessState.tone}`}>
+                      change {changeReadinessState.label.toLowerCase()}
+                    </span>
+                  </div>
+                  <div className="actionCluster">
+                    <Link
+                      href={runtimeDecisionState.primaryHref}
+                      className="landingButton primaryButton"
+                      data-testid="runtime-detail-decision-primary-action"
+                    >
+                      {runtimeDecisionState.primaryAction}
+                    </Link>
+                    <Link
+                      href={runtimeDecisionState.secondaryHref}
+                      className="secondaryButton"
+                      data-testid="runtime-detail-decision-secondary-action"
+                    >
+                      {runtimeDecisionState.secondaryAction}
+                    </Link>
+                    <button
+                      type="button"
+                      className="secondaryButton"
+                      data-testid="runtime-detail-decision-copy-button"
+                      onClick={handleCopyRuntimeNextStep}
+                    >
+                      Copy next step
+                    </button>
+                  </div>
+                </article>
+
+                <article
+                  className="runtimeDetailReviewCardsBlock"
+                  data-testid="runtime-detail-risk-breakdown-card"
+                >
+                  <div className="runtimeDetailReviewCardsHeader">
+                    <span className="eyebrow">Signals</span>
+                    <h3 data-testid="runtime-detail-risk-breakdown-title">What is shaping this review</h3>
+                  </div>
+                  <div className="workspaceReviewerGrid runtimeDetailReviewCards">
+                    {runtimeReviewGuideCards.map((card) => (
+                      <article key={card.label} className="workspaceReviewerCard">
+                        <span>{card.label}</span>
+                        <strong>{card.title}</strong>
+                        <p>{card.detail}</p>
+                      </article>
+                    ))}
+                  </div>
+                </article>
+              </div>
+
+              <aside className="workspaceGlancePanel runtimeDetailReviewAside">
+                <div className="workspaceGlanceHeader">
+                  <span className="eyebrow">Review posture</span>
+                  <strong>What is leading this page</strong>
+                </div>
+                <div className="workspaceGlanceList">
+                  {runtimeReviewPostureItems.map((item) => (
+                    <div key={item.label} className="workspaceStatusCard workspaceGlanceItem">
+                      <span>{item.label}</span>
+                      <strong>{item.value}</strong>
+                      <p>{item.detail}</p>
+                    </div>
+                  ))}
+                </div>
+                <div className="overviewAttentionItem">
+                  <div className="overviewAttentionHeader">
+                    <span className={`status ${changeReadinessState.tone}`}>
+                      change {changeReadinessState.label.toLowerCase()}
+                    </span>
+                    <strong>{changeReadinessState.focus}</strong>
+                  </div>
+                  <p>{recommendedNextStep}</p>
+                </div>
+              </aside>
             </div>
           </article>
         </div>
@@ -1602,46 +1730,6 @@ export default function DeploymentDetailsPage({ params }) {
                 </div>
               </div>
             </div>
-
-            <article className="card compactCard" data-testid="runtime-detail-risk-breakdown-card">
-              <div className="sectionHeader">
-                <div>
-                  <h2 data-testid="runtime-detail-risk-breakdown-title">Why this state is leading</h2>
-                  <p className="formHint">
-                    These signals explain why this page currently behaves like a runtime review surface or a rollout-change surface.
-                  </p>
-                </div>
-              </div>
-              <div className="workspaceReviewerGrid">
-                <article className="workspaceReviewerCard">
-                  <span>Runtime</span>
-                  <strong>{deployment?.status || "unknown"}</strong>
-                  <p>
-                    {deployment?.status === "failed"
-                      ? "A failed deployment keeps the page in incident mode until the cause is understood."
-                      : "Deployment status alone is not currently forcing an incident path."}
-                  </p>
-                </article>
-                <article className="workspaceReviewerCard">
-                  <span>Health</span>
-                  <strong>{health?.status || "unknown"}</strong>
-                  <p>
-                    {health?.status && health.status !== "healthy"
-                      ? health?.error || "Health is degraded, so the runtime still needs review."
-                      : "Health is not currently the main blocker."}
-                  </p>
-                </article>
-                <article className="workspaceReviewerCard">
-                  <span>Diagnostics</span>
-                  <strong>{diagnostics?.activity?.recent_failure_count || 0} recent failures</strong>
-                  <p>
-                    {diagnostics?.activity?.recent_failure_count > 0
-                      ? "Recent failures in diagnostics history still need explanation before the next rollout."
-                      : "Diagnostics history is not currently adding new failure pressure."}
-                  </p>
-                </article>
-              </div>
-            </article>
             </section>
 
         <section hidden={detailTab !== "change"}>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -3396,6 +3396,50 @@ button.landingButton.primaryButton:disabled {
   gap: 18px;
 }
 
+.runtimeLaneGuideStack,
+.runtimeDetailReviewStack,
+.runtimeDetailReviewCardsBlock {
+  display: grid;
+  gap: 14px;
+}
+
+.runtimeLanePrimaryCard,
+.runtimeDetailReviewPrimary {
+  gap: 16px;
+}
+
+.runtimeLaneGuideCards .workspaceReviewerCard,
+.runtimeDetailReviewCards .workspaceReviewerCard {
+  height: 100%;
+}
+
+.runtimeLaneGuideAside,
+.runtimeDetailReviewAside {
+  align-content: start;
+}
+
+.runtimeLaneGuideAside .workspaceGlanceList,
+.runtimeDetailReviewAside .workspaceGlanceList {
+  align-content: start;
+}
+
+.runtimeDetailDecisionBadges {
+  margin: 0;
+}
+
+.runtimeDetailReviewCardsHeader {
+  display: grid;
+  gap: 6px;
+}
+
+.runtimeDetailReviewCardsHeader h3 {
+  margin: 0;
+  color: #132238;
+  font-family: var(--font-display), sans-serif;
+  font-size: 24px;
+  letter-spacing: -0.03em;
+}
+
 .workspaceGuideSteps {
   align-items: stretch;
 }


### PR DESCRIPTION
## Summary
- soften the Step 3 live lane so one runtime becomes the obvious focus before the queue competes for attention
- collapse duplicated runtime detail decision/risk layers into one calmer review panel with clearer review posture
- add the supporting runtime guide styles without changing the smoke-test contract

## Verification
- npm --prefix frontend run build
- FRONTEND_SMOKE_PORT=3004 npm --prefix frontend run smoke:runtime
- bash scripts/release_workflow.sh --surface frontend